### PR TITLE
refactor: modularize core engines

### DIFF
--- a/src/audioEngine.ts
+++ b/src/audioEngine.ts
@@ -1,0 +1,131 @@
+import {
+  AudioEngine,
+  AudioParams,
+  CubeType,
+} from './core/interfaces';
+
+export class WebAudioEngine implements AudioEngine {
+  private ctx?: AudioContext;
+  private nodes = new Map<string, AudioNode>();
+  private recorder?: MediaRecorder;
+  private chunks: BlobPart[] = [];
+
+  async initialize(): Promise<void> {
+    this.ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+  }
+
+  async start(): Promise<void> {
+    await this.ctx?.resume();
+  }
+
+  async stop(): Promise<void> {
+    await this.ctx?.suspend();
+  }
+
+  createAudioNode(type: CubeType, params: AudioParams): AudioNode {
+    if (!this.ctx) throw new Error('Audio context not initialized');
+    const id = Math.random().toString(36).slice(2);
+    let node: AudioNode;
+    switch (type) {
+      case CubeType.OSCILLATOR: {
+        const osc = this.ctx.createOscillator();
+        const gain = this.ctx.createGain();
+        osc.type = 'sine';
+        if (params.frequency) osc.frequency.value = params.frequency;
+        gain.gain.value = params.gain ?? 0.2;
+        osc.connect(gain);
+        osc.start();
+        node = gain;
+        break;
+      }
+      case CubeType.FILTER: {
+        const filter = this.ctx.createBiquadFilter();
+        filter.type = 'lowpass';
+        filter.frequency.value = params.frequency ?? 1000;
+        node = filter;
+        break;
+      }
+      case CubeType.GAIN:
+      case CubeType.OUTPUT:
+      default: {
+        const gain = this.ctx.createGain();
+        gain.gain.value = params.gain ?? 1;
+        node = gain;
+        break;
+      }
+    }
+    (node as any).__id = id;
+    this.nodes.set(id, node);
+    return node;
+  }
+
+  updateAudioNode(nodeId: string, params: AudioParams): void {
+    const node = this.nodes.get(nodeId) as any;
+    if (!node) return;
+    Object.entries(params).forEach(([key, value]) => {
+      if (node[key] && typeof node[key].value === 'number') {
+        node[key].value = value;
+      }
+    });
+  }
+
+  removeAudioNode(nodeId: string): void {
+    const node = this.nodes.get(nodeId);
+    if (!node) return;
+    try {
+      (node as any).disconnect();
+    } catch {
+      /* noop */
+    }
+    this.nodes.delete(nodeId);
+  }
+
+  connectNodes(fromId: string, toId: string): void {
+    const from = this.nodes.get(fromId);
+    const to = this.nodes.get(toId);
+    if (from && to) from.connect(to);
+  }
+
+  disconnectNodes(fromId: string, toId: string): void {
+    const from = this.nodes.get(fromId);
+    const to = this.nodes.get(toId);
+    if (from && to) {
+      try {
+        from.disconnect(to);
+      } catch {
+        /* noop */
+      }
+    }
+  }
+
+  startRecording(): void {
+    if (!this.ctx) return;
+    const dest = this.ctx.createMediaStreamDestination();
+    this.nodes.forEach((n) => n.connect(dest));
+    this.recorder = new MediaRecorder(dest.stream);
+    this.chunks = [];
+    this.recorder.ondataavailable = (e) => this.chunks.push(e.data);
+    this.recorder.start();
+  }
+
+  async stopRecording(): Promise<Blob> {
+    return new Promise((resolve) => {
+      if (!this.recorder) {
+        resolve(new Blob());
+        return;
+      }
+      this.recorder.onstop = () => {
+        resolve(new Blob(this.chunks, { type: 'audio/webm' }));
+      };
+      this.recorder.stop();
+    });
+  }
+
+  getLatency(): number {
+    return this.ctx?.baseLatency ?? 0;
+  }
+
+  getCPUUsage(): number {
+    return 0;
+  }
+}

--- a/src/inputHandlers.ts
+++ b/src/inputHandlers.ts
@@ -1,0 +1,39 @@
+import * as THREE from 'three';
+import {
+  RenderEngine,
+  AudioEngine,
+  CubeInstance,
+  CubeType,
+} from './core/interfaces';
+
+export function setupInputHandlers(
+  renderEngine: RenderEngine,
+  _audioEngine: AudioEngine,
+): void {
+  window.addEventListener('resize', () => {
+    renderEngine.setSize(window.innerWidth, window.innerHeight);
+  });
+
+  window.addEventListener('click', (event) => {
+    const pointer = new THREE.Vector2(
+      (event.clientX / window.innerWidth) * 2 - 1,
+      -(event.clientY / window.innerHeight) * 2 + 1,
+    );
+    const hits = renderEngine.raycast(pointer);
+    if (hits.length === 0) {
+      const cube: CubeInstance = {
+        id: `cube-${Date.now()}`,
+        type: CubeType.OSCILLATOR,
+        transform: {
+          position: new THREE.Vector3(),
+          rotation: new THREE.Vector3(),
+          scale: new THREE.Vector3(1, 1, 1),
+        },
+        audioNodeId: '',
+        isActive: true,
+        parameters: {},
+      };
+      renderEngine.addCube(cube);
+    }
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,299 +1,44 @@
 import * as THREE from 'three';
-import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { ThreeRenderEngine } from './renderEngine';
+import { WebAudioEngine } from './audioEngine';
+import { setupInputHandlers } from './inputHandlers';
+import { CubeInstance, CubeType } from './core/interfaces';
 
-interface Cube {
-  mesh: THREE.Mesh;
-  type: string;
-  audioIn: AudioNode | null;
-  audioOut: AudioNode | null;
-}
+const renderEngine = new ThreeRenderEngine();
+const audioEngine = new WebAudioEngine();
 
-interface Connection {
-  from: Cube;
-  to: Cube;
-  line: THREE.Line;
-}
-
-const scene = new THREE.Scene();
-const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
-camera.position.set(5, 5, 5);
-
-const renderer = new THREE.WebGLRenderer({ antialias: true });
-renderer.setSize(window.innerWidth, window.innerHeight);
-document.body.appendChild(renderer.domElement);
-
-let controls: OrbitControls | null = null;
-
-async function init(): Promise<void> {
-  const module = await import('three/examples/jsm/controls/OrbitControls.js');
-  controls = new module.OrbitControls(camera, renderer.domElement);
-  controls.enableDamping = true;
-  setupTutorial();
+async function initializeApp(): Promise<void> {
+  renderEngine.initializeScene();
+  await audioEngine.initialize();
+  setupInputHandlers(renderEngine, audioEngine);
   animate();
 }
 
-const raycaster = new THREE.Raycaster();
-const pointer = new THREE.Vector2();
+function animate(): void {
+  requestAnimationFrame(animate);
+  renderEngine.render();
+}
 
-// Mesa
-const planeGeo = new THREE.PlaneGeometry(20, 20);
-const planeMat = new THREE.MeshBasicMaterial({ color: 0x222222, side: THREE.DoubleSide });
-const plane = new THREE.Mesh(planeGeo, planeMat);
-plane.rotation.x = -Math.PI / 2;
-scene.add(plane);
-
-// Iluminación
-const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1);
-scene.add(light);
-
-// Audio context
-const audioCtx = new (window.AudioContext || (window as any).webkitAudioContext)();
-audioCtx.resume();
-
-const cubes: Cube[] = [];
-let connections: Connection[] = [];
-let selected: Cube | null = null;
-let dragging = false;
-let rotating = false;
-const dragOffset = new THREE.Vector3();
-
-function createCube(type: string, position: THREE.Vector3): Cube {
-  const colors: Record<string, number> = { osc: 0x00aaff, filter: 0xffaa00, output: 0xaa00ff };
-  const geo = new THREE.BoxGeometry(1, 1, 1);
-  const mat = new THREE.MeshStandardMaterial({ color: colors[type] || 0xffffff });
-  const mesh = new THREE.Mesh(geo, mat);
-  mesh.position.copy(position);
-  mesh.scale.set(0.01, 0.01, 0.01);
-  scene.add(mesh);
-  animateAppearance(mesh);
-
-  let audioIn: AudioNode | null = null;
-  let audioOut: AudioNode | null = null;
-  if (type === 'osc') {
-    const osc = audioCtx.createOscillator();
-    osc.type = 'sine';
-    const gain = audioCtx.createGain();
-    gain.gain.value = 0.2;
-    osc.connect(gain);
-    gain.connect(audioCtx.destination);
-    osc.start();
-    audioOut = gain;
-    (mesh.userData as any).osc = osc;
-  } else if (type === 'filter') {
-    const input = audioCtx.createGain();
-    const filter = audioCtx.createBiquadFilter();
-    filter.type = 'lowpass';
-    filter.frequency.value = 1000;
-    const output = audioCtx.createGain();
-    input.connect(filter);
-    filter.connect(output);
-    output.connect(audioCtx.destination);
-    audioIn = input;
-    audioOut = output;
-    (mesh.userData as any).filter = filter;
-  } else if (type === 'output') {
-    const input = audioCtx.createGain();
-    input.connect(audioCtx.destination);
-    audioIn = input;
-  }
-
-  const cube: Cube = { mesh, type, audioIn, audioOut };
-  cubes.push(cube);
-  updateConnections();
+export function createCube(
+  type: CubeType,
+  position: THREE.Vector3,
+): CubeInstance {
+  const cube: CubeInstance = {
+    id: `cube-${Date.now()}`,
+    type,
+    transform: {
+      position,
+      rotation: new THREE.Vector3(),
+      scale: new THREE.Vector3(1, 1, 1),
+    },
+    audioNodeId: '',
+    isActive: true,
+    parameters: {},
+  };
+  renderEngine.addCube(cube);
   return cube;
 }
 
-function updateConnections(): void {
-  connections.forEach((c) => {
-    if (c.from.audioOut && c.to.audioIn) {
-      try {
-        c.from.audioOut.disconnect(c.to.audioIn);
-      } catch (e) {
-        /* noop */
-      }
-    }
-    scene.remove(c.line);
-    (c.line.geometry as THREE.BufferGeometry).dispose();
-    (c.line.material as THREE.Material).dispose();
-  });
-  connections = [];
+export { renderEngine, audioEngine, initializeApp };
 
-  const threshold = 2.5;
-  for (let i = 0; i < cubes.length; i++) {
-    for (let j = i + 1; j < cubes.length; j++) {
-      const a = cubes[i];
-      const b = cubes[j];
-      const dist = a.mesh.position.distanceTo(b.mesh.position);
-      if (dist < threshold) {
-        if (a.audioOut && b.audioIn) {
-          a.audioOut.connect(b.audioIn);
-          const line = createLine(a.mesh.position, b.mesh.position);
-          connections.push({ from: a, to: b, line });
-        }
-        if (b.audioOut && a.audioIn) {
-          b.audioOut.connect(a.audioIn);
-          const line = createLine(b.mesh.position, a.mesh.position);
-          connections.push({ from: b, to: a, line });
-        }
-      }
-    }
-  }
-}
-
-function createLine(a: THREE.Vector3, b: THREE.Vector3): THREE.Line {
-  const points = [a.clone(), b.clone()];
-  const geo = new THREE.BufferGeometry().setFromPoints(points);
-  const mat = new THREE.LineBasicMaterial({ color: 0x00ff00 });
-  const line = new THREE.Line(geo, mat);
-  scene.add(line);
-  return line;
-}
-
-function animateAppearance(mesh: THREE.Mesh): void {
-  const target = new THREE.Vector3(1, 1, 1);
-  function grow() {
-    mesh.scale.lerp(target, 0.2);
-    if (mesh.scale.distanceTo(target) > 0.01) {
-      requestAnimationFrame(grow);
-    } else {
-      mesh.scale.set(1, 1, 1);
-    }
-  }
-  grow();
-}
-
-function setupTutorial(): void {
-  const tutorial = document.getElementById('tutorial');
-  const btn = document.getElementById('startBtn');
-  if (!localStorage.getItem('tutorialSeen')) {
-    tutorial?.classList.remove('hidden');
-  }
-  btn?.addEventListener('click', () => {
-    tutorial?.classList.add('hidden');
-    localStorage.setItem('tutorialSeen', '1');
-  });
-}
-
-function onPointerDown(event: PointerEvent): void {
-  pointer.x = (event.clientX / window.innerWidth) * 2 - 1;
-  pointer.y = -(event.clientY / window.innerHeight) * 2 + 1;
-  raycaster.setFromCamera(pointer, camera);
-  const intersects = raycaster.intersectObjects(cubes.map((c) => c.mesh));
-  if (intersects.length > 0) {
-    selected = cubes.find((c) => c.mesh === intersects[0].object) || null;
-    const planeIntersect = raycaster.intersectObject(plane)[0];
-    dragOffset.copy(planeIntersect.point).sub(selected!.mesh.position);
-    dragging = true;
-  } else {
-    const planeHit = raycaster.intersectObject(plane)[0];
-    if (planeHit) {
-      const type = (document.getElementById('cubeType') as HTMLSelectElement).value;
-      selected = createCube(type, planeHit.point.add(new THREE.Vector3(0, 0.5, 0)));
-    }
-  }
-}
-
-function onPointerMove(event: PointerEvent): void {
-  if (!dragging && !rotating) return;
-  pointer.x = (event.clientX / window.innerWidth) * 2 - 1;
-  pointer.y = -(event.clientY / window.innerHeight) * 2 + 1;
-  raycaster.setFromCamera(pointer, camera);
-  const planeIntersect = raycaster.intersectObject(plane)[0];
-  if (planeIntersect) {
-    if (dragging && selected) {
-      const pos = planeIntersect.point.sub(dragOffset);
-      selected.mesh.position.set(pos.x, selected.mesh.position.y, pos.z);
-      updateConnections();
-    }
-    if (rotating && selected) {
-      selected.mesh.rotation.y += event.movementX * 0.01;
-      applyParams(selected);
-    }
-  }
-}
-
-function onPointerUp(): void {
-  dragging = false;
-}
-
-function onKeyDown(event: KeyboardEvent): void {
-  if (event.key === 'r' || event.key === 'R') {
-    if (selected) rotating = true;
-  }
-  if (event.key === 'Delete') {
-    if (selected) removeCube(selected);
-  }
-}
-
-function onKeyUp(event: KeyboardEvent): void {
-  if (event.key === 'r' || event.key === 'R') rotating = false;
-}
-
-function removeCube(cube: Cube): void {
-  const idx = cubes.indexOf(cube);
-  if (idx >= 0) {
-    if (cube.audioOut && (cube.audioOut as any).disconnect) cube.audioOut.disconnect();
-    if (cube.audioIn && (cube.audioIn as any).disconnect) cube.audioIn.disconnect();
-    if ((cube.mesh.userData as any).osc) (cube.mesh.userData as any).osc.stop();
-    scene.remove(cube.mesh);
-    cube.mesh.geometry.dispose();
-    (cube.mesh.material as THREE.Material).dispose();
-    cubes.splice(idx, 1);
-    selected = null;
-    updateConnections();
-  }
-}
-
-function applyParams(cube: Cube): void {
-  const rotY = cube.mesh.rotation.y;
-  if (cube.type === 'osc' && (cube.mesh.userData as any).osc) {
-    (cube.mesh.userData as any).osc.frequency.value = 220 + rotY * 100;
-  } else if (cube.type === 'filter' && (cube.mesh.userData as any).filter) {
-    const freq = THREE.MathUtils.clamp(1000 + rotY * 500, 100, 5000);
-    (cube.mesh.userData as any).filter.frequency.value = freq;
-  } else if (cube.type === 'output' && cube.audioIn) {
-    const vol = THREE.MathUtils.clamp(0.5 + rotY * 0.1, 0, 1);
-    (cube.audioIn as GainNode).gain.value = vol;
-  }
-}
-
-window.addEventListener('pointerdown', onPointerDown);
-window.addEventListener('pointermove', onPointerMove);
-window.addEventListener('pointerup', onPointerUp);
-window.addEventListener('keydown', onKeyDown);
-window.addEventListener('keyup', onKeyUp);
-
-window.addEventListener('resize', () => {
-  camera.aspect = window.innerWidth / window.innerHeight;
-  camera.updateProjectionMatrix();
-  renderer.setSize(window.innerWidth, window.innerHeight);
-});
-
-function animate(): void {
-  requestAnimationFrame(animate);
-  if (controls) controls.update();
-  connections.forEach((c) => {
-    const positions = (c.line.geometry as THREE.BufferGeometry).attributes.position
-      .array as Float32Array;
-    positions[0] = c.from.mesh.position.x;
-    positions[1] = c.from.mesh.position.y;
-    positions[2] = c.from.mesh.position.z;
-    positions[3] = c.to.mesh.position.x;
-    positions[4] = c.to.mesh.position.y;
-    positions[5] = c.to.mesh.position.z;
-    (c.line.geometry as THREE.BufferGeometry).attributes.position.needsUpdate = true;
-  });
-  renderer.render(scene, camera);
-}
-
-function cleanup(): void {
-  cubes.slice().forEach((c) => removeCube(c));
-  renderer.dispose();
-}
-
-window.addEventListener('beforeunload', cleanup);
-
-Object.assign(window as any, { createCube, cubes, THREE, scene });
-
-init();
-
+initializeApp();

--- a/src/renderEngine.ts
+++ b/src/renderEngine.ts
@@ -1,0 +1,133 @@
+import * as THREE from 'three';
+import {
+  RenderEngine,
+  CubeInstance,
+  Transform3D,
+  CameraController,
+  RaycastResult,
+} from './core/interfaces';
+
+export class ThreeRenderEngine implements RenderEngine {
+  private scene = new THREE.Scene();
+  private camera = new THREE.PerspectiveCamera(
+    60,
+    window.innerWidth / window.innerHeight,
+    0.1,
+    1000,
+  );
+  private renderer = new THREE.WebGLRenderer({ antialias: true });
+  private cubes = new Map<string, THREE.Mesh>();
+  private connections = new Map<string, THREE.Line>();
+  private raycaster = new THREE.Raycaster();
+  private controller?: CameraController;
+
+  initializeScene(): void {
+    this.camera.position.set(5, 5, 5);
+    this.renderer.setSize(window.innerWidth, window.innerHeight);
+    document.body.appendChild(this.renderer.domElement);
+
+    const planeGeo = new THREE.PlaneGeometry(20, 20);
+    const planeMat = new THREE.MeshBasicMaterial({
+      color: 0x222222,
+      side: THREE.DoubleSide,
+    });
+    const plane = new THREE.Mesh(planeGeo, planeMat);
+    plane.rotation.x = -Math.PI / 2;
+    this.scene.add(plane);
+
+    const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1);
+    this.scene.add(light);
+  }
+
+  addCube(cube: CubeInstance): void {
+    const geo = new THREE.BoxGeometry(1, 1, 1);
+    const mat = new THREE.MeshStandardMaterial({ color: 0xffffff });
+    const mesh = new THREE.Mesh(geo, mat);
+    mesh.position.copy(cube.transform.position);
+    mesh.rotation.set(
+      cube.transform.rotation.x,
+      cube.transform.rotation.y,
+      cube.transform.rotation.z,
+    );
+    mesh.scale.copy(cube.transform.scale);
+    this.scene.add(mesh);
+    this.cubes.set(cube.id, mesh);
+  }
+
+  removeCube(cubeId: string): void {
+    const mesh = this.cubes.get(cubeId);
+    if (!mesh) return;
+    this.scene.remove(mesh);
+    mesh.geometry.dispose();
+    (mesh.material as THREE.Material).dispose();
+    this.cubes.delete(cubeId);
+  }
+
+  updateCube(cubeId: string, transform: Transform3D): void {
+    const mesh = this.cubes.get(cubeId);
+    if (!mesh) return;
+    mesh.position.copy(transform.position);
+    mesh.rotation.set(
+      transform.rotation.x,
+      transform.rotation.y,
+      transform.rotation.z,
+    );
+    mesh.scale.copy(transform.scale);
+  }
+
+  setCameraController(controller: CameraController): void {
+    this.controller = controller;
+  }
+
+  showConnection(from: string, to: string, intensity: number): void {
+    const a = this.cubes.get(from);
+    const b = this.cubes.get(to);
+    if (!a || !b) return;
+    const points = [a.position.clone(), b.position.clone()];
+    const geo = new THREE.BufferGeometry().setFromPoints(points);
+    const mat = new THREE.LineBasicMaterial({
+      color: 0x00ff00,
+      linewidth: intensity,
+    });
+    const line = new THREE.Line(geo, mat);
+    this.scene.add(line);
+    this.connections.set(`${from}-${to}`, line);
+  }
+
+  hideConnection(from: string, to: string): void {
+    const key = `${from}-${to}`;
+    const line = this.connections.get(key);
+    if (!line) return;
+    this.scene.remove(line);
+    (line.geometry as THREE.BufferGeometry).dispose();
+    (line.material as THREE.Material).dispose();
+    this.connections.delete(key);
+  }
+
+  raycast(screenPosition: THREE.Vector2): RaycastResult[] {
+    this.raycaster.setFromCamera(screenPosition, this.camera);
+    const intersects = this.raycaster.intersectObjects(
+      Array.from(this.cubes.values()),
+    );
+    return intersects.map((i) => ({ object: i.object, point: i.point }));
+  }
+
+  render(): void {
+    if (this.controller) this.controller.update();
+    this.renderer.render(this.scene, this.camera);
+  }
+
+  setSize(width: number, height: number): void {
+    this.renderer.setSize(width, height);
+    this.camera.aspect = width / height;
+    this.camera.updateProjectionMatrix();
+  }
+
+  getScene(): THREE.Scene {
+    return this.scene;
+  }
+
+  getCamera(): THREE.Camera {
+    return this.camera;
+  }
+}


### PR DESCRIPTION
## Summary
- split main app logic into dedicated render, audio, and input modules
- implement interfaces for Three.js scene and Web Audio handling
- centralize initialization and exports in new main entry

## Testing
- `npm test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/webkit-2203/pw_run.sh)*
- `npx playwright install` *(fails: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b85f35447c8325a776dd2fcd959644